### PR TITLE
Inline manifest option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ module.exports = {
   plugins: [
     new ChunkManifestPlugin({
       filename: "manifest.json",
-      manifestVariable: "webpackManifest"
+      manifestVariable: "webpackManifest",
+      inlineManifest: false
     })
   ]
 };
@@ -42,3 +43,15 @@ Where the manifest will be exported to on bundle compilation. This will be relat
 #### `manifestVariable`
 
 What JS variable on the client webpack should refer to when requiring chunks. Default = `"webpackManifest"`
+
+#### `inlineManifest`
+
+Whether or not to write the manifest output into the [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin). Default = `false`
+
+```html
+// index.ejs
+<body>
+    <!-- app -->
+    <%= htmlWebpackPlugin.files.webpackManifest %>
+</body>
+```

--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -56,6 +56,10 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
     });
 
     if (inlineManifest){
+      compilation.plugin("html-webpack-plugin-before-html-generation", function (data, callback) {
+        var manifestHtml = "<script>window." + manifestVariable + "=" + JSON.stringify(chunkManifest) + "</script>";
+        callback(null, data.assets[manifestVariable] = manifestHtml);
+      });
     }
   });
 };

--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -14,12 +14,12 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
   var manifestVariable = this.manifestVariable;
   var inlineManifest = this.inlineManifest;
   var oldChunkFilename;
+  var chunkManifest;
 
   compiler.plugin("this-compilation", function(compilation) {
     var mainTemplate = compilation.mainTemplate;
     mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
       var filename = this.outputOptions.chunkFilename || this.outputOptions.filename;
-      var chunkManifest;
 
       if (filename) {
         chunkManifest = [chunk].reduce(function registerChunk(manifest, c) {

--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -4,6 +4,7 @@ function ChunkManifestPlugin(options) {
   options = options || {};
   this.manifestFilename = options.filename || "manifest.json";
   this.manifestVariable = options.manifestVariable || "webpackManifest";
+  this.inlineManifest = options.inlineManifest || false;
 }
 module.exports = ChunkManifestPlugin;
 
@@ -11,6 +12,7 @@ ChunkManifestPlugin.prototype.constructor = ChunkManifestPlugin;
 ChunkManifestPlugin.prototype.apply = function(compiler) {
   var manifestFilename = this.manifestFilename;
   var manifestVariable = this.manifestVariable;
+  var inlineManifest = this.inlineManifest;
   var oldChunkFilename;
 
   compiler.plugin("this-compilation", function(compilation) {
@@ -52,5 +54,8 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
       return _.replace("\"__CHUNK_MANIFEST__\"",
         "window[\"" + manifestVariable + "\"][" + chunkIdVar + "]");
     });
+
+    if (inlineManifest){
+    }
   });
 };


### PR DESCRIPTION
Similar to #15. Adds `options.inlineManifest` for users who implement [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin);

```javascript
// webpack.config.js
new ChunkManifestPlugin({
    inlineManifest: true
}),

new HtmlWebpackPlugin({
    template: 'index.ejs'
}),
```

```html
<!-- index.ejs -->
<body>
    <%= htmlWebpackPlugin.files.webpackManifest %>
</body>
```