### PR TITLE
Update webpack peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "webpack-core": "^0.6.9"
   },
   "peerDependencies": {
-    "webpack": "^2.0.0"
+    "webpack": "^2.0.0 || ^2.1.0-beta || ^2.2.0-rc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will fix

```
$ npm ls
...
npm ERR! peer dep missing: webpack@^2.0.0, required by chunk-manifest-webpack-plugin@1.0.0
```

When using this plugin with Webpack 2.2 RC (https://medium.com/webpack/webpack-2-2-the-release-candidate-2e614d05d75f#.5tiqow96v) or Webpack 2.1 beta