### PR TITLE
Change `window` to `self` to support web workers

### DIFF
--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -50,7 +50,7 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
       }
 
       return _.replace("\"__CHUNK_MANIFEST__\"",
-        "window[\"" + manifestVariable + "\"][" + chunkIdVar + "]");
+        "self[\"" + manifestVariable + "\"][" + chunkIdVar + "]");
     });
   });
 };


### PR DESCRIPTION
self === window in the main thread, meaning this change will not break any users of the plugin and can be considered a patch release.