### PR TITLE
Add manifest to the current chunk

### DIFF
--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -37,6 +37,7 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
         this.outputOptions.chunkFilename = "__CHUNK_MANIFEST__";
         // mark as asset for emitting
         compilation.assets[manifestFilename] = new RawSource(JSON.stringify(chunkManifest));
+        chunk.files.push(manifestFilename);
       }
 
       return _;


### PR DESCRIPTION
Correctly add the emitted manifest file to the current chunk. This, for example, fixes Webpack statistics where the manifest wouldn't be there in `assetsByChunkName` otherwise.