### PR TITLE
quick & dirty merge chunk manifests for configs with multiple entry points

### DIFF
--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -38,7 +38,13 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
         oldChunkFilename = this.outputOptions.chunkFilename;
         this.outputOptions.chunkFilename = "__CHUNK_MANIFEST__";
         // mark as asset for emitting
-        compilation.assets[manifestFilename] = new RawSource(JSON.stringify(chunkManifest));
+        var mergedAssets;
+        if (compilation.assets[manifestFilename]) {
+          mergedAssets = Object.assign({}, JSON.parse(compilation.assets[manifestFilename]._value), chunkManifest);
+        } else {
+          mergedAssets = chunkManifest;
+        }
+        compilation.assets[manifestFilename] = new RawSource(JSON.stringify(mergedAssets));
         chunk.files.push(manifestFilename);
       }
 


### PR DESCRIPTION
almost certainly solves: https://github.com/soundcloud/chunk-manifest-webpack-plugin/issues/6
there's definitely a better solution-- i'll write something cleaner shortly. in the meantime, this is what I'm using locally. 

Issue is that the chunk manifest is being overwritten for every entry point chunk.