### PR TITLE
#26 add note to readme when plugin silently fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ Whether or not to write the manifest output into the [html-webpack-plugin](https
     <%= htmlWebpackPlugin.files.webpackManifest %>
 </body>
 ```
+
+### Note
+
+* Webpack configurations that set `watch: true` won't generate a file and will cause this plugin to silently fail. This includes both `webpack-dev-server` and `webpack-dev-middleware`.


### PR DESCRIPTION
I spent plenty of time yesterday looking for a reason why the `manifest.json` was not being generated. To save others time I recommend adding a note like the one in this PR to the README. A fix or some kind of hard failure would be nicer of course.