### PR TITLE
Prepend global window object to emitted file if inlineManifest flag i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ What JS variable on the client webpack should refer to when requiring chunks. De
 
 #### `inlineManifest`
 
-Whether or not to write the manifest output into the [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin). Default = `false`
+Whether or not to write the manifest output into the [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) as well as prepend the global window object as `window.{manifestVariable} =` to the emitted file. Default = `false`
 
 ```html
 // index.ejs

--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -38,7 +38,7 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
         oldChunkFilename = this.outputOptions.chunkFilename;
         this.outputOptions.chunkFilename = "__CHUNK_MANIFEST__";
         // mark as asset for emitting
-        compilation.assets[manifestFilename] = new RawSource(JSON.stringify(chunkManifest));
+        compilation.assets[manifestFilename] = new RawSource(generateManifestString());
         chunk.files.push(manifestFilename);
       }
 
@@ -58,9 +58,18 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
 
     if (inlineManifest){
       compilation.plugin("html-webpack-plugin-before-html-generation", function (data, callback) {
-        var manifestHtml = "<script>window." + manifestVariable + "=" + JSON.stringify(chunkManifest) + "</script>";
+        var manifestHtml = "<script>" + generateManifestString() + "</script>";
         callback(null, data.assets[manifestVariable] = manifestHtml);
       });
     }
   });
+
+  function generateManifestString() {
+    let manifestString = JSON.stringify(chunkManifest);
+    // prepend global window object to file emitted if manifest is used inline
+    if (inlineManifest){
+      manifestString = "window." + manifestVariable + "=" + manifestString;
+    }
+    return manifestString;
+  }
 };


### PR DESCRIPTION
Allows the emitted file to be used inline without the use of https://github.com/jouni-kantola/inline-chunk-manifest-html-webpack-plugin.