### PR TITLE
Fix Webpack v3.4.0 compatibility issue

### DIFF
--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -25,9 +25,13 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
         chunkManifest = [chunk].reduce(function registerChunk(manifest, c) {
           if(c.id in manifest) return manifest;
 
-          if((typeof c.hasRuntime === 'function' && c.hasRuntime()) || c.entry) {
+          if(typeof c.hasRuntime === 'function' && c.hasRuntime()) {
             manifest[c.id] = undefined;
-          } else {
+          }
+          else if (typeof c.hasRuntime !== 'function' && c.entry) {
+            manifest[c.id] = undefined;
+          }
+          else {
             manifest[c.id] = mainTemplate.applyPluginsWaterfall("asset-path", filename, {
               hash: hash,
               chunk: c


### PR DESCRIPTION
## Summary

`Chunk.entry` has been deprecated and any attempt at accessing it throws an error.

This fixes an issue found while creating a bundle with Webpack v3.4.0:

```
ERROR in chunk vendor [entry]
js/vendor.[hash].js
Chunk.entry was removed. Use hasRuntime()
```

Among other issues that may be related to this issue: #43, #45.