### PR TITLE
Fix another regression introduced in 1.1.1

### DIFF
--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -39,7 +39,6 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
         this.outputOptions.chunkFilename = "__CHUNK_MANIFEST__";
         // mark as asset for emitting
         compilation.assets[manifestFilename] = new RawSource(JSON.stringify(chunkManifest));
-        chunk.files.push(manifestFilename);
       }
 
       return _;


### PR DESCRIPTION
If using a separate entry for the webpack runtime, it starts pointing to the manifest file.