### PR TITLE
Add package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "chunk-manifest-webpack-plugin",
+  "version": "1.1.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.s-cloud.net/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "source-list-map": {
+      "version": "0.1.8",
+      "resolved": "https://npm.dev.s-cloud.net/source-list-map/-/source-list-map-0.1.8.tgz",
+      "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY="
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://npm.dev.s-cloud.net/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "webpack-core": {
+      "version": "0.6.9",
+      "resolved": "https://npm.dev.s-cloud.net/webpack-core/-/webpack-core-0.6.9.tgz",
+      "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
+      "requires": {
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.4.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Security Update: Add package-lock.json
======================================

Following a [recent incident](https://blog.npmjs.org/post/175824896885/incident-report-npm-inc-operations-incident-of) we are attempting to update all projects using node to node 8 and ensure all libraries have a package-lock.json. Whilst this will only affect developers of the library itself, it does add some small mitigations for thesee types of incidents.

What you need to do now?
------------------------

As long as this is just a library, there's nothing really to test, just merge this PR and be thankful for the additional safety.
